### PR TITLE
Fix undo 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,9 @@ All notable changes to the "ruby-format-vscode" extension will be documented in 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+
+- Use STDIN for formatting to preserve undo, open the way for format on save.
+
+## 0.0.3
+
 - Initial release

--- a/README.md
+++ b/README.md
@@ -22,5 +22,3 @@ gem install rufo
 ### Gotchas
 
 * It supports only the whole file formatting. Formatting a selected block of code is not supported yet.
-
-* As the modification of file happens outside the editer using the gem, cannot use undo operation. This is a [known issue](https://github.com/Microsoft/vscode/issues/2908) with vs code and hopefully gets fixed soon.

--- a/extension.js
+++ b/extension.js
@@ -1,37 +1,41 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-var vscode = require('vscode');
-const exec = require('child_process').execSync;
+var vscode = require("vscode");
+const exec = require("child_process").execSync;
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 function activate(context) {
+  // Use the console to output diagnostic information (console.log) and errors (console.error)
+  // This line of code will only be executed once when your extension is activated
+  console.log(
+    'Congratulations, your extension "ruby-format-vscode" is now active!'
+  );
 
-    // Use the console to output diagnostic information (console.log) and errors (console.error)
-    // This line of code will only be executed once when your extension is activated
-    console.log('Congratulations, your extension "ruby-format-vscode" is now active!');
-
-    // The command has been defined in the package.json file
-    // Now provide the implementation of the command with  registerCommand
-    // The commandId parameter must match the command field in package.json
-    var formatRuby = vscode.commands.registerCommand('extension.formatRuby', function () {
-        let editor = vscode.window.activeTextEditor
-        if (!editor)  return;
-        try {
-            exec("rufo "+vscode.window.activeTextEditor.document.fileName)
-        } catch(err) {
-            if(err.message.includes("command not found")){
-                vscode.window.showErrorMessage("rufo not available in path. Ensure rufo gem is installed")
-            }
+  // The command has been defined in the package.json file
+  // Now provide the implementation of the command with  registerCommand
+  // The commandId parameter must match the command field in package.json
+  var formatRuby = vscode.commands.registerCommand(
+    "extension.formatRuby",
+    function() {
+      let editor = vscode.window.activeTextEditor;
+      if (!editor) return;
+      try {
+        exec(`rufo "${vscode.window.activeTextEditor.document.fileName}"`);
+      } catch (err) {
+        if (err.message.includes("command not found")) {
+          vscode.window.showErrorMessage(
+            "rufo not available in path. Ensure rufo gem is installed"
+          );
         }
-    });
+      }
+    }
+  );
 
-
-    context.subscriptions.push(formatRuby);
+  context.subscriptions.push(formatRuby);
 }
 exports.activate = activate;
 
 // this method is called when your extension is deactivated
-function deactivate() {
-}
+function deactivate() {}
 exports.deactivate = deactivate;

--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,8 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-var vscode = require("vscode");
-const exec = require("child_process").execSync;
+const vscode = require("vscode");
+const { Range, Position } = vscode;
+const exec = require("child_process").exec;
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -21,12 +22,21 @@ function activate(context) {
       let editor = vscode.window.activeTextEditor;
       if (!editor) return;
       try {
-        exec(`rufo "${vscode.window.activeTextEditor.document.fileName}"`);
+        const documentText = editor.document.getText();
+        const child = exec("rufo", (error, stdout, stderr) => {
+          if (error || stderr) console.log("ERROR", error, stderr);
+          const formattedText = stdout;
+          replaceDocumentWithFormatted(editor, formattedText);
+        });
+        child.stdin.write(documentText);
+        child.stdin.end();
       } catch (err) {
         if (err.message.includes("command not found")) {
           vscode.window.showErrorMessage(
             "rufo not available in path. Ensure rufo gem is installed"
           );
+        } else {
+          vscode.window.showErrorMessage(err.message);
         }
       }
     }
@@ -39,3 +49,14 @@ exports.activate = activate;
 // this method is called when your extension is deactivated
 function deactivate() {}
 exports.deactivate = deactivate;
+
+function replaceDocumentWithFormatted(editor, formattedText) {
+  // Build a Range spanning the entire document, start to finish
+  const lastLine = editor.document.lineCount - 1;
+  const lastChar = editor.document.lineAt(lastLine).range.end;
+  const range = new Range(new Position(0, 0), new Position(lastLine, lastChar));
+  // Build an edit that replaces the document with the new formatted version
+  const editCb = editBuilder => editBuilder.replace(range, formattedText);
+
+  return editor.edit(editCb);
+}

--- a/test/test-formatter.rb
+++ b/test/test-formatter.rb
@@ -1,0 +1,8 @@
+class MyClass
+    def indent
+  "all_wrong"
+  end
+
+    def eww
+  end
+end


### PR DESCRIPTION
By using `rufo`'s STDIN based format, we can apply the edit from inside VS Code, which means

- undo works!
- the door to selection based edits is opened
- the door to format on save is opened